### PR TITLE
"group" option was broken on jQuery 1.7

### DIFF
--- a/jquery.hoverIntent.js
+++ b/jquery.hoverIntent.js
@@ -234,9 +234,16 @@
                     fnout.apply(this.cible, arguments);
                 });
 
-            return this.bind('mouseenter mouseleave mousemove', function(evt) {
-                $.event.handle.call(spectre, evt);
+            this.bind('mouseenter', function(evt) {
+                $(spectre).trigger('mouseenter', evt);
             });
+            this.bind('mouseleave', function(evt) {
+                $(spectre).trigger('mouseleave', evt);
+            });
+            this.bind('mousemove', function(evt) {
+                $(spectre).trigger('mousemove', evt);
+            });
+            return this;
         }
         // Both events will be manage with the same HoverIntent instance, so we can set options just on the second one, it will impact the first event too.
         return this

--- a/jquery.hoverIntent.js
+++ b/jquery.hoverIntent.js
@@ -234,14 +234,8 @@
                     fnout.apply(this.cible, arguments);
                 });
 
-            this.bind('mouseenter', function(evt) {
-                $(spectre).trigger('mouseenter', evt);
-            });
-            this.bind('mouseleave', function(evt) {
-                $(spectre).trigger('mouseleave', evt);
-            });
-            this.bind('mousemove', function(evt) {
-                $(spectre).trigger('mousemove', evt);
+            this.bind('mouseenter mouseleave mousemove', function(evt) {
+                $(spectre).trigger(evt.type, evt);
             });
             return this;
         }


### PR DESCRIPTION
I'm pretty sure this regression was caused by a change of internals in jQuery 1.7. You are using the undocumented function $.event.handle to proxy the events, and I patched the library to use $.fn.trigger instead.
