### PR TITLE
Compatibility for jQuery 1.9.0+

### DIFF
--- a/libs/jquery.hoverIntent.js
+++ b/libs/jquery.hoverIntent.js
@@ -117,7 +117,7 @@
         triggerEvent : function triggerEvent() {
             this.inside = !this.inside;
             this.event.type = this.inside ? 'mouseenterintent' : 'mouseleaveintent';
-            $.event.handle.call(this.elem, this.event);
+            $.event.dispatch.call(this.elem, this.event);
         },
 
         // for mouseEnter, we have some things to do before throwing the event


### PR DESCRIPTION
See http://forum.jquery.com/topic/alternative-to-event-handle-in-1-9-0

Don't know if it breaks the compatibility with lower versions.
